### PR TITLE
gitlabci to push docs, Use pyproject version in docs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,7 +27,7 @@ docs:
                 - apk add make git
                 - poetry install -vvv
                 - make docs
-                - sh push.sh dry
+                - sh push.sh
         only:
                 - tags
                 - master

--- a/docs/apiminer.rst
+++ b/docs/apiminer.rst
@@ -1,6 +1,10 @@
 apiminer package
 ================
 
+:Release: |release|
+
+-------------------
+
 Submodules
 ----------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@
 #
 import os
 import sys
+from tomlkit import parse as tomlparse
 
 sys.path.insert(0, os.path.abspath("../"))
 
@@ -24,11 +25,11 @@ project = "apiminer"
 copyright = "2018, C. Pannell"
 author = "C. Pannell"
 
-# The short X.Y version
-version = "v0.1"
 # The full version, including alpha/beta/rc tags
-release = "v0.1.0"
-
+with open("../pyproject.toml", "r") as f:
+    release = tomlparse(f.read())["tool"]["poetry"]["version"]
+# The short X.Y version
+version = ".".join(release.split(".")[:2])
 
 # -- General configuration ---------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "apiminer"
-version = "0.1.0"
+version = "0.1.1"
 description = "apiminer is a Python package that handles communications with your miner APIs so you don’t have to."
 authors = ["W. Clayton Pannell <clayton.pannell@gmail.com>"]
 license = "BSD-3-Clause"
@@ -18,6 +18,7 @@ pytest-mock = "^1.10"
 Black = {version = "^19.3b0",allows-prereleases = true,python = "^3.6"}
 codecov = "^2.0"
 pytest-cov = "^2.7"
+tomlkit = "^0.5.3"
 
 [tool.tox]
 legacy_tox_ini = """


### PR DESCRIPTION
Add version to docs

Change 'sh push dry' to 'sh push' to actually do the push

adds tomlkit to dev dependencies, but much, much cleaner than ripping it out with string manipulation

Version is visible on 'apiminer package' page

version bump to 0.1.1